### PR TITLE
fix: correctly render and hydrate app shell

### DIFF
--- a/e2e/solid-start/basic/app/client.tsx
+++ b/e2e/solid-start/basic/app/client.tsx
@@ -1,8 +1,8 @@
 /// <reference types="vinxi/types/client" />
-import { createRouter } from './router'
 import { hydrate } from 'solid-js/web'
-import { RouterProvider } from '@tanstack/solid-router'
+import { StartClient } from '@tanstack/solid-start'
+import { createRouter } from './router'
 
 const router = createRouter()
 
-hydrate(() => <RouterProvider router={router} />, document)
+hydrate(() => <StartClient router={router} />, document.body)

--- a/e2e/solid-start/basic/app/routes/__root.tsx
+++ b/e2e/solid-start/basic/app/routes/__root.tsx
@@ -1,13 +1,8 @@
 import {
-  HeadContent,
   Link,
   Outlet,
-  Scripts,
   createRootRoute,
 } from '@tanstack/solid-router'
-
-import * as Solid from 'solid-js'
-import { Hydration, HydrationScript, NoHydration } from 'solid-js/web'
 
 import { NotFound } from '~/components/NotFound'
 import appCss from '~/styles/app.css?url'
@@ -56,9 +51,77 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <RootDocument>
+    <>
+      <div class="p-2 flex gap-2 text-lg">
+        <Link
+          to="/"
+          activeProps={{
+            class: 'font-bold',
+          }}
+          activeOptions={{ exact: true }}
+        >
+          Home
+        </Link>{' '}
+        <Link
+          to="/posts"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Posts
+        </Link>{' '}
+        <Link
+          to="/users"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Users
+        </Link>{' '}
+        <Link
+          to="/layout-a"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Layout
+        </Link>{' '}
+        <Link
+          to="/scripts"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Scripts
+        </Link>{' '}
+        <Link
+          to="/deferred"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          Deferred
+        </Link>{' '}
+        <Link
+          to="/redirect"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          redirect
+        </Link>{' '}
+        <Link
+          // @ts-expect-error
+          to="/this-route-does-not-exist"
+          activeProps={{
+            class: 'font-bold',
+          }}
+        >
+          This Route Does Not Exist
+        </Link>
+      </div>
       <Outlet />
-    </RootDocument>
+    </>
   )
 }
 
@@ -71,90 +134,3 @@ function RootComponent() {
 //           default: res.TanStackRouterDevtools,
 //         })),
 //       )
-
-function RootDocument({ children }: { children: Solid.JSX.Element }) {
-  return (
-    <html>
-      <head>
-        <HeadContent />
-        <HydrationScript />
-      </head>
-      <body>
-        <div id="app">
-          <div class="p-2 flex gap-2 text-lg">
-            <Link
-              to="/"
-              activeProps={{
-                class: 'font-bold',
-              }}
-              activeOptions={{ exact: true }}
-            >
-              Home
-            </Link>{' '}
-            <Link
-              to="/posts"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              Posts
-            </Link>{' '}
-            <Link
-              to="/users"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              Users
-            </Link>{' '}
-            <Link
-              to="/layout-a"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              Layout
-            </Link>{' '}
-            <Link
-              to="/scripts"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              Scripts
-            </Link>{' '}
-            <Link
-              to="/deferred"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              Deferred
-            </Link>{' '}
-            <Link
-              to="/redirect"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              redirect
-            </Link>{' '}
-            <Link
-              // @ts-expect-error
-              to="/this-route-does-not-exist"
-              activeProps={{
-                class: 'font-bold',
-              }}
-            >
-              This Route Does Not Exist
-            </Link>
-          </div>
-
-          <Hydration>{children}</Hydration>
-
-          <Scripts />
-        </div>
-      </body>
-    </html>
-  )
-}

--- a/packages/solid-router/src/HeadContent.tsx
+++ b/packages/solid-router/src/HeadContent.tsx
@@ -1,4 +1,5 @@
 import * as Solid from 'solid-js'
+import { useAssets } from 'solid-js/web'
 import { Asset } from './Asset'
 import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
@@ -130,7 +131,8 @@ export const useTags = () => {
  */
 export function HeadContent() {
   const tags = useTags()
-  return tags.map((tag) => <Asset {...tag} />)
+  useAssets(() => tags.map((tag) => <Asset {...tag} />))
+  return null
 }
 
 function uniqBy<T>(arr: Array<T>, fn: (item: T) => string) {

--- a/packages/solid-start-client/src/StartClient.tsx
+++ b/packages/solid-start-client/src/StartClient.tsx
@@ -1,8 +1,11 @@
 import { Await, RouterProvider } from '@tanstack/solid-router'
 import { hydrate } from './ssr-client'
 import type { AnyRouter } from '@tanstack/solid-router'
+import type { JSXElement } from 'solid-js'
 
 let hydrationPromise: Promise<void | Array<Array<void>>> | undefined
+
+const Dummy = (props: { children?: JSXElement }) => <>{props.children}</>
 
 export function StartClient(props: { router: AnyRouter }) {
   if (!hydrationPromise) {
@@ -15,7 +18,21 @@ export function StartClient(props: { router: AnyRouter }) {
   return (
     <Await
       promise={hydrationPromise}
-      children={() => <RouterProvider router={props.router} />}
+      children={() => (
+        <Dummy>
+          <Dummy>
+            <RouterProvider
+              router={props.router}
+              InnerWrap={(props) => (
+                <Dummy>
+                  <Dummy>{props.children}</Dummy>
+                  <Dummy />
+                </Dummy>
+              )}
+            />
+          </Dummy>
+        </Dummy>
+      )}
     />
   )
 }

--- a/packages/solid-start-server/src/StartServer.tsx
+++ b/packages/solid-start-server/src/StartServer.tsx
@@ -1,8 +1,34 @@
-import { RouterProvider } from '@tanstack/solid-router'
+import { HeadContent, RouterProvider, Scripts } from '@tanstack/solid-router'
+import { Hydration, HydrationScript, NoHydration, ssr } from 'solid-js/web'
 import type { AnyRouter } from '@tanstack/solid-router'
+
+const docType = ssr('<!DOCTYPE html>')
 
 export function StartServer<TRouter extends AnyRouter>(props: {
   router: TRouter
 }) {
-  return <RouterProvider router={props.router} />
+  return (
+    <NoHydration>
+      {docType as any}
+      <html>
+        <head>
+          <HydrationScript />
+        </head>
+        <body>
+          <Hydration>
+            <RouterProvider
+              router={props.router}
+              InnerWrap={(props) => (
+                <NoHydration>
+                  <HeadContent />
+                  <Hydration>{props.children}</Hydration>
+                  <Scripts />
+                </NoHydration>
+              )}
+            />
+          </Hydration>
+        </body>
+      </html>
+    </NoHydration>
+  )
 }

--- a/packages/solid-start-server/src/defaultRenderHandler.tsx
+++ b/packages/solid-start-server/src/defaultRenderHandler.tsx
@@ -10,7 +10,7 @@ export const defaultRenderHandler = defineHandlerCallback(
         router.serverSsr!.injectedHtml,
       ).then((htmls) => htmls.join(''))
       html = html.replace(`</body>`, `${injectedHtml}</body>`)
-      return new Response(`<!DOCTYPE html>${html}`, {
+      return new Response(html, {
         status: router.state.statusCode,
         headers: responseHeaders,
       })

--- a/packages/solid-start-server/src/defaultStreamHandler.tsx
+++ b/packages/solid-start-server/src/defaultStreamHandler.tsx
@@ -1,71 +1,31 @@
-import { PassThrough } from 'node:stream'
 import { isbot } from 'isbot'
 import * as Solid from 'solid-js/web'
 
 import { StartServer } from './StartServer'
 
-import {
-  transformPipeableStreamWithRouter,
-  transformReadableStreamWithRouter,
-} from './transformStreamWithRouter'
+import { transformReadableStreamWithRouter } from './transformStreamWithRouter'
 
 import { defineHandlerCallback } from './handlerCallback'
 import type { ReadableStream } from 'node:stream/web'
 
 export const defaultStreamHandler = defineHandlerCallback(
-  ({ request, router, responseHeaders }) => {
-    if (typeof Solid.renderToStream === 'function') {
-      const stream = Solid.renderToStream(() => <StartServer router={router} />)
+  async ({ request, router, responseHeaders }) => {
+    const { writable, readable } = new TransformStream()
 
-      const { writable, readable } = new TransformStream()
-      stream.pipeTo(writable)
+    const stream = Solid.renderToStream(() => <StartServer router={router} />)
 
-      const responseStream = transformReadableStreamWithRouter(
-        router,
-        readable as unknown as ReadableStream,
-      )
-      return new Response(responseStream as any, {
-        status: router.state.statusCode,
-        headers: responseHeaders,
-      })
+    if (isbot(request.headers.get('User-Agent'))) {
+      await stream
     }
+    stream.pipeTo(writable)
 
-    if (typeof Solid.renderToStream === 'function') {
-      const reactAppPassthrough = new PassThrough()
-
-      try {
-        const pipeable = Solid.renderToStream(
-          () => <StartServer router={router} />,
-          {
-            ...(isbot(request.headers.get('User-Agent'))
-              ? {
-                  onCompleteAll() {
-                    pipeable.pipe(reactAppPassthrough)
-                  },
-                }
-              : {
-                  onCompleteShell() {
-                    pipeable.pipe(reactAppPassthrough)
-                  },
-                }),
-          },
-        )
-      } catch (e) {
-        console.error('Error in renderToPipeableStream:', e)
-      }
-
-      const responseStream = transformPipeableStreamWithRouter(
-        router,
-        reactAppPassthrough,
-      )
-      return new Response(responseStream as any, {
-        status: router.state.statusCode,
-        headers: responseHeaders,
-      })
-    }
-
-    throw new Error(
-      'No renderToReadableStream or renderToPipeableStream found in react-dom/server. Ensure you are using a version of react-dom that supports streaming.',
+    const responseStream = transformReadableStreamWithRouter(
+      router,
+      readable as unknown as ReadableStream,
     )
+    return new Response(responseStream as any, {
+      status: router.state.statusCode,
+      headers: responseHeaders,
+    })
   },
 )

--- a/packages/solid-start-server/src/transformStreamWithRouter.ts
+++ b/packages/solid-start-server/src/transformStreamWithRouter.ts
@@ -1,5 +1,4 @@
 import { ReadableStream } from 'node:stream/web'
-import { Readable } from 'node:stream'
 import { createControlledPromise } from '@tanstack/solid-router'
 import type { AnyRouter } from '@tanstack/solid-router'
 
@@ -8,15 +7,6 @@ export function transformReadableStreamWithRouter(
   routerStream: ReadableStream,
 ) {
   return transformStreamWithRouter(router, routerStream)
-}
-
-export function transformPipeableStreamWithRouter(
-  router: AnyRouter,
-  routerStream: Readable,
-) {
-  return Readable.fromWeb(
-    transformStreamWithRouter(router, Readable.toWeb(routerStream)),
-  )
 }
 
 // regex pattern for matching closing body and html tags

--- a/packages/solid-start-server/vite.config.ts
+++ b/packages/solid-start-server/vite.config.ts
@@ -6,7 +6,10 @@ import minifyScriptPlugin from './vite-minify-plugin'
 import type { ViteUserConfig } from 'vitest/config'
 
 const config = defineConfig({
-  plugins: [minifyScriptPlugin(), solid()] as ViteUserConfig['plugins'],
+  plugins: [
+    minifyScriptPlugin(),
+    solid({ solid: { generate: 'ssr' } }),
+  ] as ViteUserConfig['plugins'],
   test: {
     name: packageJson.name,
     watch: false,


### PR DESCRIPTION
This diverges how the `__root.tsx` file work with `@tanstack/react-start`, mainly due to `dom-expressions` gets buggy on transforming `<head>` tags on client side.